### PR TITLE
Service para host

### DIFF
--- a/service/codersbot.service
+++ b/service/codersbot.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Bot do Discord da Coders Community
+
+[Service]
+ExecStart=/root/go/bin/CodersGoBot/bot
+WorkingDirectory=/root/go/bin/CodersGoBot
+User=root
+Group=root
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/service/codersbot.service
+++ b/service/codersbot.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Bot do Discord da Coders Community
+StartLimitBurst=30
+StartLimitIntervalSec=150
 
 [Service]
 ExecStart=/root/go/bin/CodersGoBot/bot
@@ -7,6 +9,7 @@ WorkingDirectory=/root/go/bin/CodersGoBot
 User=root
 Group=root
 Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/service/systemd.sh
+++ b/service/systemd.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 service_path="/etc/systemd/system"
+ln_service_path="lib/systemd/system"
 bin_path="/root/go/bin/CodersGoBot"
 
 if [ "$EUID" -ne 0 ]
@@ -32,5 +33,10 @@ cp ./.env "${bin_path}"
 echo "Build efetuada com sucesso."
 cp ./service/codersbot.service "${service_path}"
 
-systemctl enable --now codersbot.service
+systemctl start codersbot.service
+systemctl enable codersbot.service
+if [ ! -f "${ln_service_path}/codersbot.service" ];
+then
+    ln -s /etc/systemd/system/codersbot.service /lib/systemd/system
+fi
 echo "Serviço criado e iniciado."

--- a/service/systemd.sh
+++ b/service/systemd.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+service_path="/etc/systemd/system"
+bin_path="/root/go/bin/CodersGoBot"
+
+if [ "$EUID" -ne 0 ]
+then 
+    echo "Por favor, rode o script como root."
+    echo "Saindo..."
+    exit 1
+fi
+
+if ! [ -x "$(command -v go)" ];
+then
+    echo "Parece que você não possui Go instalado no sistema. Go é necessário para rodar o nosso bot, então por favor, primeiro instale ele e depois tente executar o script novamente."
+    echo "Saindo..."
+    exit 1
+fi
+
+if [[ "$(pwd)" == *service ]]
+then
+    cd ..
+fi
+
+if [ ! -d "$bin_path" ];
+then
+    mkdir /root/go/bin/CodersGoBot
+fi
+
+go build -o "${bin_path}/bot"
+cp ./.env "${bin_path}"
+echo "Build efetuada com sucesso."
+cp ./service/codersbot.service "${service_path}"
+
+systemctl enable --now codersbot.service
+echo "Serviço criado e iniciado."

--- a/service/systemd.sh
+++ b/service/systemd.sh
@@ -27,7 +27,6 @@ if [ ! -d "$bin_path" ];
 then
     mkdir /root/go/bin/CodersGoBot
 fi
-
 go build -o "${bin_path}/bot"
 cp ./.env "${bin_path}"
 echo "Build efetuada com sucesso."


### PR DESCRIPTION
Foi adicionado um simples arquivo .service, bem como um script de automação para a inicialização e configuração do service para o init system systemd. Isso foi feito com o intuito de facilitar o hosteamento futuro do bot em servidores linux.

Foi testado tanto na minha máquina principal (Arch Linux), quanto em um Raspberry Pi (Raspbian Bullseye).

![image](https://user-images.githubusercontent.com/36492293/176581730-1ce2ddc2-41f5-4c4b-8b3d-658ae6d3866a.png)