### PR TITLE
feat: Updating the discordgo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Coders-Community-BR/CodersGoBot
 go 1.18
 
 require (
-	github.com/bwmarrin/discordgo v0.25.0
+	github.com/bwmarrin/discordgo v0.25.1-0.20220714214021-0feaae8f1b39
 	github.com/joho/godotenv v1.4.0
 	github.com/sirupsen/logrus v1.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/bwmarrin/discordgo v0.25.0 h1:NXhdfHRNxtwso6FPdzW2i3uBvvU7UIQTghmV2T4nqAs=
 github.com/bwmarrin/discordgo v0.25.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
+github.com/bwmarrin/discordgo v0.25.1-0.20220714214021-0feaae8f1b39 h1:x5gu9JdBqvH0tWiMf9ScQVVFECyQhmTEJuOiReOHDDQ=
+github.com/bwmarrin/discordgo v0.25.1-0.20220714214021-0feaae8f1b39/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=


### PR DESCRIPTION
I'm building a `ban` command, and of course i need to restrict permissions, but on discordgo [v0.25.0](https://github.com/bwmarrin/discordgo/tree/v0.25.0), there is no `DefaultMemberPermissions`, so we can't handle permissions in slash commands. My solution is to **Temporarily** use a pseudo-version, just while discordgo doesn't release a new version.